### PR TITLE
Bug fix in open video check

### DIFF
--- a/src/main/java/gov/nasa/jpl/memex/pooledtimeseries/PoT.java
+++ b/src/main/java/gov/nasa/jpl/memex/pooledtimeseries/PoT.java
@@ -367,6 +367,7 @@ public class PoT {
 
     VideoCapture capture = new VideoCapture(filename.toString());
 
+    if (!capture.isOpened()) {
       LOG.warning("video file not opened.");
       
       double[][][] hist = new double[w_d][h_d][o_d];


### PR DESCRIPTION
It looks like the latest changes to fix some issues with video loading caused an if statement to get dropped. Everything builds fine for me now after fixing this.