### PR TITLE
Fix for bad video files

### DIFF
--- a/src/main/java/gov/nasa/jpl/memex/pooledtimeseries/PoTException.java
+++ b/src/main/java/gov/nasa/jpl/memex/pooledtimeseries/PoTException.java
@@ -1,0 +1,18 @@
+package gov.nasa.jpl.memex.pooledtimeseries;
+
+/**
+ * Created by Aditya on 10/29/15.
+ */
+public class PoTException extends Exception {
+    //Parameterless Constructor
+    private PoTException() {}
+
+    //Constructor that accepts a message
+    public PoTException(String message)
+    {
+        super(message);
+        this.message = message;
+    }
+
+    public String message;
+}


### PR DESCRIPTION
If dataset contains a bad video which cannot be read
or produces an exception while calculating
flow or gradient vectors, then we skip over that file and continue
as if it wasn't included in the dataset.

However, we report such a file in the LOG.