### PR TITLE
PoT issue 17

### DIFF
--- a/src/main/java/gov/nasa/jpl/memex/pooledtimeseries/PoT.java
+++ b/src/main/java/gov/nasa/jpl/memex/pooledtimeseries/PoT.java
@@ -107,6 +107,13 @@ public class PoT {
         .withDescription("Set similarity output format to JSON. Defaults to .txt")
         .create('j');
 
+    Option similarityFromFeatureVectorsOpt = OptionBuilder
+            .withArgName("similarity from FeatureVectors directory")
+            .withLongOpt("similarityFromFeatureVectorsDirectory")
+            .hasArg()
+            .withDescription("calculate similarity matrix from given directory of feature vectors")
+            .create('s');
+
     Options options = new Options();
     options.addOption(dirOpt);
     options.addOption(pathFileOpt);
@@ -114,6 +121,7 @@ public class PoT {
     options.addOption(helpOpt);
     options.addOption(outputFileOpt);
     options.addOption(jsonOutputFlag);
+    options.addOption(similarityFromFeatureVectorsOpt);
 
     // create the parser
     CommandLineParser parser = new DefaultParser();
@@ -124,6 +132,7 @@ public class PoT {
       String directoryPath = null;
       String pathFile = null;
       String singleFilePath = null;
+      String similarityFromFeatureVectorsDirectory = null;
       ArrayList<Path> videoFiles = null;
 
       if (line.hasOption("dir")) {
@@ -144,6 +153,13 @@ public class PoT {
 
       if (line.hasOption("json")) {
           outputFormat = OUTPUT_FORMATS.JSON;
+      }
+
+      System.out.println(line.hasOption("similarityFromFeatureVectorsDirectory"));
+
+      if (line.hasOption("similarityFromFeatureVectorsDirectory")) {
+        similarityFromFeatureVectorsDirectory = line.getOptionValue("similarityFromFeatureVectorsDirectory");
+        System.out.println(similarityFromFeatureVectorsDirectory);
       }
 
       if (line.hasOption("help")
@@ -192,7 +208,33 @@ public class PoT {
     	  videoFiles.add(singleFile);
       }
 
-      evaluateSimilarity(videoFiles, 0);
+      if (similarityFromFeatureVectorsDirectory != null) {
+        File dir = new File(similarityFromFeatureVectorsDirectory);
+        List<File> files = (List<File>) FileUtils.listFiles(dir,
+                TrueFileFilter.INSTANCE, TrueFileFilter.INSTANCE);
+        videoFiles = new ArrayList<Path>(files.size());
+
+        for (File file : files) {
+          String filePath = file.toString();
+
+          // We need to load only the *.of.txt and *.hog.txt values
+          if (filePath.endsWith(".of.txt")) {
+            videoFiles.add(file.toPath());
+          }
+
+          if (filePath.endsWith(".hog.txt")) {
+            videoFiles.add(file.toPath());
+          }
+        }
+
+        LOG.info("Added " + videoFiles.size() + " feature vectors from "
+                + similarityFromFeatureVectorsDirectory);
+        evaluateSimilarity(videoFiles, 1);
+      }
+
+      else {
+        evaluateSimilarity(videoFiles, 0);
+      }
       LOG.info("done.");
 
     } catch (ParseException exp) {
@@ -217,7 +259,10 @@ public class PoT {
         Path file = files.get(k);
 
         // optical flow descriptors
-        String series_name1 = file.toString() + ".of.txt";
+        String series_name1 = file.toString();
+        if (!series_name1.endsWith(".of.txt")) {
+          series_name1 += ".of.txt";
+        }
         Path series_path1 = Paths.get(series_name1);
         double[][] series1;
 
@@ -232,7 +277,10 @@ public class PoT {
         multi_series.add(series1);
 
         // gradients descriptors
-        String series_name2 = file.toString() + ".hog.txt";
+        String series_name2 = file.toString();
+        if (!series_name2.endsWith(".hog.txt")) {
+          series_name2 += ".hog.txt";
+        }
         Path series_path2 = Paths.get(series_name2);
         double[][] series2;
 

--- a/src/main/java/gov/nasa/jpl/memex/pooledtimeseries/PoT.java
+++ b/src/main/java/gov/nasa/jpl/memex/pooledtimeseries/PoT.java
@@ -260,7 +260,7 @@ public class PoT {
 
         // optical flow descriptors
         String series_name1 = file.toString();
-        if (!series_name1.endsWith(".of.txt")) {
+        if ((!series_name1.endsWith(".of.txt")) && (!series_name1.endsWith(".hog.txt"))) {
           series_name1 += ".of.txt";
         }
         Path series_path1 = Paths.get(series_name1);
@@ -278,7 +278,7 @@ public class PoT {
 
         // gradients descriptors
         String series_name2 = file.toString();
-        if (!series_name2.endsWith(".hog.txt")) {
+        if ((!series_name2.endsWith(".hog.txt")) && (!series_name2.endsWith(".of.txt"))) {
           series_name2 += ".hog.txt";
         }
         Path series_path2 = Paths.get(series_name2);


### PR DESCRIPTION
Added an option to run similarity matrix calculation form pre-existing feature vectors.
These featurevectors are expected to be stored in *.of.txt for optical flow descriptors and *.hog.txt for histogram of gradient vectors.
The similarity matrix is stored in ./similarity.txt by default (you can pass in -o <output-file> to store it elsewhere)